### PR TITLE
Added a maxdepth 1 to the find command when looking for jars. This wi…

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -90,7 +90,7 @@ if [ ! -z "${BUCKETS}" ] ; then
   done
 fi
 
-export JAR_FILE=`find ${HOME} -name "*.jar"`
+export JAR_FILE=`find ${HOME} -maxdepth 1 -name "*.jar"`
 
 echo "java ${JAVA_OPTS} -jar ${JAR_FILE}"
 java ${JAVA_OPTS} -jar ${JAR_FILE}


### PR DESCRIPTION
…ll restrict the run.sh command to only running jars in the home directory directly. Also will fix an annoyance where find gets a permission denied error on .pki/nssdb